### PR TITLE
Disable screen saver only when the app is active

### DIFF
--- a/Recorder/Main.qml
+++ b/Recorder/Main.qml
@@ -82,7 +82,7 @@ MainView {
 
     ScreenSaver {
         id: screenSaver
-        screenSaverEnabled: !settings.disableScreenSaver
+        screenSaverEnabled: !settings.disableScreenSaver || !Qt.application.active
     }
 
     Recorder {


### PR DESCRIPTION
Currently when "Keep screen on" option is set to true, it affects all system. The phone's screen is turned on even if the Recorder app is in the background. This commit will change it so the screen will be on only if the Recorder app is active.