### PR TITLE
Add 16.04 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ po/template.pot
 
 # click
 *.click
+
+# clickable
+build/*

--- a/Recorder/Main.qml
+++ b/Recorder/Main.qml
@@ -179,7 +179,7 @@ MainView {
             for (var i = 0; i < codec_list.length; i++) {
                 var codec = codec_list[i]
                 var codec_item = { name: codec, value: codec}
-                if (codec === "audio/vorbis") {
+                if (codec === "audio/x-vorbis") {
                     codec_item.name = i18n.tr("%1 (default)").arg(codec_item.name)
                     recorder.codecData.default_index = i
                 }
@@ -194,7 +194,7 @@ MainView {
             for (var i = 0; i < container_list.length; i++) {
                 var container = container_list[i]
                 var container_item = { name: container, value: container }
-                if (container === "ogg") {
+                if (container === "audio/ogg") {
                     container_item.name = i18n.tr("%1 (default)").arg(container_item.name)
                     recorder.containerData.default_index = i
                 }

--- a/Recorder/Recorder.apparmor
+++ b/Recorder/Recorder.apparmor
@@ -6,5 +6,5 @@
         "content_exchange_source",
         "keep-display-on"
     ],
-    "policy_version": 1.3
+    "policy_version": 16.04
 }

--- a/Recorder/audiorecorder.cpp
+++ b/Recorder/audiorecorder.cpp
@@ -47,8 +47,8 @@ AudioRecorder::AudioRecorder(QObject *parent) : QObject(parent)
     }
 
     // default audio settings
-    m_audioCodec = "audio/vorbis";
-    m_fileContainer = "ogg";
+    m_audioCodec = "audio/x-vorbis";
+    m_fileContainer = "audio/ogg";
     m_channels = 2;
     m_encodingMode = QualityMode;
     m_encodingQuality = NormalQuality;
@@ -147,7 +147,7 @@ void AudioRecorder::setAudioCodec(const QString &codec)
 {
     QString _codec = codec;
     if (_codec == "default") {
-        _codec = "audio/vorbis";
+        _codec = "audio/x-vorbis";
     }
 
     if (_codec != m_audioCodec) {
@@ -160,7 +160,7 @@ void AudioRecorder::setFileContainer(const QString &container)
 {
     QString _container = container;
     if (_container == "default") {
-        _container = "ogg";
+        _container = "audio/ogg";
     }
 
     if (_container != m_fileContainer) {
@@ -228,7 +228,7 @@ void AudioRecorder::record()
 
     m_audioRecorder->setVolume(m_microphoneVolume / 100.0);
     m_audioSettings.setCodec(m_audioCodec);
-    if (m_audioCodec != "audio/vorbis") {
+    if (m_audioCodec != "audio/x-vorbis") {
         m_audioSettings.setChannelCount(m_channels);
     }
     m_audioSettings.setEncodingMode((QMultimedia::EncodingMode)m_encodingMode);
@@ -339,7 +339,7 @@ QString AudioRecorder::newFileName()
     QString fileExtension;
     if (m_fileContainer == "matroska") {
         fileExtension = "mkv";
-    } else if (m_fileContainer == "ogg") {
+    } else if (m_fileContainer == "audio/ogg") {
         fileExtension = "ogg";
     } else if (m_fileContainer == "wav") {
         fileExtension = "wav";

--- a/Recorder/ui/SelectionPage.qml
+++ b/Recorder/ui/SelectionPage.qml
@@ -31,7 +31,7 @@ Page {
 
     function selectCodec(index, data) {
         settings.audioCodec = data
-        if (data === "audio/vorbis") {
+        if (data === "audio/x-vorbis") {
             settings.channels = 1
         }
     }

--- a/Recorder/ui/SettingsPage.qml
+++ b/Recorder/ui/SettingsPage.qml
@@ -341,7 +341,7 @@ Page {
             }
 
             ListItem {
-                visible: settingsPage.state === "advanced" && settings.audioCodec !== "audio/vorbis" && settings.audioCodec !== "default"
+                visible: settingsPage.state === "advanced" && settings.audioCodec !== "audio/x-vorbis" && settings.audioCodec !== "default"
                 height: visible ? channelLayout.height + (divider.visible ? divider.height : 0) : 0
                 highlightColor: "#246588"
 

--- a/clickable.json
+++ b/clickable.json
@@ -1,0 +1,3 @@
+{
+  "template": "qmake"
+}

--- a/manifest.json.in
+++ b/manifest.json.in
@@ -6,7 +6,7 @@
     "hooks": {
         "Recorder": {
             "apparmor": "Recorder/Recorder.apparmor",
-            "desktop": "Recorder/Recorder.desktop",
+            "desktop": "/Recorder/Recorder.desktop",
             "content-hub": "Recorder/Recorder-content.json"
         }
     },

--- a/manifest.json.in
+++ b/manifest.json.in
@@ -12,5 +12,5 @@
     },
     "version": "1.0.3",
     "maintainer": "DawnDIY <dawndiy.dev@gmail.com>",
-    "framework": "ubuntu-sdk-15.04.6"
+    "framework": "ubuntu-sdk-16.04"
 }


### PR DESCRIPTION
It builds an installable click for 16.04. But there are still two issues:

 - [x] Starter (desktop file) does not get installed. Weird: it works if the desktop file is moved inside the click package from `./Recorder/*.desktop` to `./*.desktop` in the data.tar.gz. More weird: Solved by adding and `/` in front of the desktop file path.
 - [x] Audio recording does not work (solved as suggested in ubports/ubuntu-touch/issues/529). This was the log output:
```
ERROR: "Not compatible codecs and container format."
qml: Not compatible codecs and container format.
ERROR: "Not compatible codecs and container format."
qml: Not compatible codecs and container format.
Could not create a media muxer element: ""
ERROR: "Failed to build media capture pipeline."
qml: Failed to build media capture pipeline.
```